### PR TITLE
Search highlighting and badges adjustments

### DIFF
--- a/src/components/docs/SearchResults.vue
+++ b/src/components/docs/SearchResults.vue
@@ -37,30 +37,30 @@
 
     li {
       margin-bottom: 4px;
+
+      .badge {
+        display: inline-block;
+        width: 0.8rem;
+        margin-left: 0;
+        margin-right: 8px;
+        padding: 3px 4px;
+        text-align: center;
+        font-size: 0.9rem;
+        opacity: 1;
+        transition: background-color 0.3s;
+      }
+
+      .score {
+        display: inline-block;
+        position: relative;
+        right: 1.7rem;
+        width: 0;
+        margin: 0;
+        font-size: 0.7rem;
+        overflow: visible;
+        color: lighten($color-content-text, 40%);
+      }
     }
-  }
-
-  .badge {
-    display: inline-block;
-    width: 0.8rem;
-    margin-left: 0;
-    margin-right: 8px;
-    padding: 3px 4px;
-    text-align: center;
-    font-size: 0.9rem;
-    opacity: 1;
-    transition: background-color 0.3s;
-  }
-
-  .score {
-    display: inline-block;
-    position: relative;
-    right: 1.7rem;
-    width: 0;
-    margin: 0;
-    font-size: 0.7rem;
-    overflow: visible;
-    color: lighten($color-content-text, 40%);
   }
 
   #app.dark .results-list .score {

--- a/src/components/docs/SearchResults.vue
+++ b/src/components/docs/SearchResults.vue
@@ -22,7 +22,7 @@
 
     computed: {
       searchRegex() {
-        return new RegExp(this.searchTerm, 'i');
+        return new RegExp(this.searchTerm, 'ig');
       },
     },
   };


### PR DESCRIPTION
Somehow missed this in my last PR but the `.badge` and `.score` selectors in the SearchResults component should've gone under the `.results-list li` selector. Without doing so, it affected other badges around the site.
In addition, the regex for highlighting now uses the `g` flag so that multiple occurrences of things like `client`, for example, will get highlighted.