### PR TITLE
Fix a problem query not passed when press enter on search

### DIFF
--- a/src/components/docs/Navbar.vue
+++ b/src/components/docs/Navbar.vue
@@ -52,7 +52,7 @@
       },
 
       goToSearch() {
-        if (this.$route.name !== 'docs-search') this.$router.push({ name: 'docs-search' });
+        if (this.$route.name !== 'docs-search') this.$router.push({ name: 'docs-search', query: { q: this.search } });
       },
     },
 


### PR DESCRIPTION
To reproduce:

1. Search something like "message"
2. Click the first result to view to doc
3. Focus on search input, notice "message" is still there
4. Press enter
5. Router goes to search page with error "Your search query must be at least two characters."， with the input box still shows "message"

![2018-05-04_10-35-23](https://user-images.githubusercontent.com/1743179/39642520-e15bba34-4f86-11e8-9307-fd5b27582d4e.png)
