### PR TITLE
Fix a problem query not passed when change tag on search

### DIFF
--- a/src/components/docs/Navbar.vue
+++ b/src/components/docs/Navbar.vue
@@ -64,7 +64,7 @@
       tagChoice(tag) {
         if (tag && this.$route.params.tag !== tag) {
           SHITS.switching = true;
-          this.$router.push({ name: this.$route.name, params: { ...this.$route.params, tag } });
+          this.$router.push({ name: this.$route.name, params: { ...this.$route.params, tag }, query: this.$route.query });
         }
       },
 


### PR DESCRIPTION
To reproduce:

- Search something like "message"
- Change tag
- Router goes to search page with error "Your search query must be at least two characters."， with the input box still shows "message"