### PR TITLE
Increase the visibility of search box placeholder

### DIFF
--- a/src/components/docs/Navbar.vue
+++ b/src/components/docs/Navbar.vue
@@ -127,6 +127,10 @@ export default {
       border-bottom: 1px solid #aaa;
       transition: border-color 0.3s;
 
+      &::placeholder, &:-ms-input-placeholder {
+        color: #aaa;
+      }
+
       &:focus {
         border-color: $color-primary;
         outline: none;


### PR DESCRIPTION
This PR changes search box placeholder color to gray to increase the visibility

from
![image](https://user-images.githubusercontent.com/21266306/65896806-e5460580-e3e8-11e9-8f2a-b9a4ced3e4fa.png)
to
![image](https://user-images.githubusercontent.com/21266306/65896830-eaa35000-e3e8-11e9-980e-199cec385044.png)
