### PR TITLE
feat(Navbar): add a link to the discord.js guide

### DIFF
--- a/src/components/AppNavbar.vue
+++ b/src/components/AppNavbar.vue
@@ -5,7 +5,8 @@
 
       <nav>
         <router-link to="/docs">Documentation</router-link><!--
-        --><a :href="`https://github.com/${repository}`">GitHub</a>
+        --><a :href="`https://github.com/${repository}`">GitHub</a><!--
+        --><a href="https://discordjs.guide/">Guide</a>
       </nav>
     </container>
   </header>

--- a/src/components/AppNavbar.vue
+++ b/src/components/AppNavbar.vue
@@ -21,6 +21,7 @@ export default {
 
 <style lang="scss">
   @import '../styles/theming';
+  @import '../styles/mq';
 
   header {
     height: 3rem;
@@ -32,6 +33,12 @@ export default {
       padding: 0 16px;
       text-decoration: none;
       color: white;
+    }
+
+    @include mq($until: tablet) {
+      a {
+        padding: 0 7px;
+      }
     }
 
     & .container > a {


### PR DESCRIPTION
This PR adds a link on the navbar to the discord.js guide, which helps with users finding it/knowing there is a guide.