### PR TITLE
feat: add copy to clipboard button

### DIFF
--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -2,7 +2,9 @@
   <div id="home">
     <slide id="jumbotron">
       <logo :light="true" :konami="konami" id="logo" />
-      <code>npm install discord.js</code><br />
+      <button v-on:click="copyCode" ref="code" id="code-button" title="Copy Command to Clipboard">
+        <code>npm install discord.js</code>
+      </button>
     </slide>
 
     <section id="info">
@@ -79,6 +81,14 @@ export default {
     Stats,
   },
 
+  methods: {
+    copyCode() {
+      const code = this.$refs.code.textContent;
+      navigator.clipboard.writeText(code)
+        .catch(e => console.log(e));
+    },
+  },
+
   mounted() {
     this.$emit('setRepository', MainSource.repo);
   },
@@ -132,6 +142,10 @@ export default {
         background: #f5f5f5;
         color: $color-content-text;
         font-family: $font-monospace;
+      }
+
+      code:hover {
+        background-color: #ddf;
       }
     }
 
@@ -214,4 +228,16 @@ export default {
       color: darken($color-content-text-dark, 20%);
     }
   }
+
+  #code-button {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 5px;
+  }
+
+  #code-button:active {
+    transform: translateY(4px);
+  }
+
 </style>

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -142,10 +142,10 @@ export default {
         background: #f5f5f5;
         color: $color-content-text;
         font-family: $font-monospace;
-      }
 
-      code:hover {
-        background-color: #ddf;
+        &:hover {
+          background-color: #ddf;
+        }
       }
     }
 
@@ -234,10 +234,10 @@ export default {
     padding: 0;
     border: 0;
     border-radius: 5px;
-  }
 
-  #code-button:active {
-    transform: translateY(4px);
+    &:active {
+      transform: translateY(4px);
+    }
   }
 
 </style>


### PR DESCRIPTION
closes: #56
ℹ️ preview: https://semi-useful-feature.netlify.app

This PR turns the `npm install discord.js` into a button with "copy to clipboard" functionality. It was a cool feature request, so I thought why not. Aight, I've tested it and it works like a charm but here is the thing: I know nothing about vue except the things I looked up for making this stuff, so please don't shout if I broke anything. k thanks! 👻