### PR TITLE
fix(search): adjusted some values to reduce the number of ties in search comparison function

### DIFF
--- a/src/util/search.ts
+++ b/src/util/search.ts
@@ -148,18 +148,18 @@ export function search(input: string): DocumentLink[] {
 			// Give extra weight when an exact match is found
 			// if it is a class or typedef, give it even higher priority
 			if (aref.nameLowerCase === formattedInput) {
-				weight += aref.isPriority ? -10 : -5;
+				weight += aref.isPriority ? -10 : -4;
 			} else if (bref.nameLowerCase === formattedInput) {
-				weight += bref.isPriority ? 10 : 5;
+				weight += bref.isPriority ? 10 : 4;
 			}
 
 			if (a === b) {
 				// if the counter is the same but not the names, then give extra weight to ones that are classes and typedefs
 				if (aref.isPriority) {
-					weight -= 5;
+					weight -= 6;
 				}
 				if (bref.isPriority) {
-					weight += 5;
+					weight += 6;
 				}
 
 				// in the case that there are more than two index matches, sort them by how close their length is to the input


### PR DESCRIPTION
Currently when searching for "guild" on firefox, GuildChannelManager is the first result. Guild doesn't even show up on the quick list. This PR hopefully reduces the scenarios where this kind of thing can happen in different browsers. 

Unfortunately I don't have safari, so if someone could test that out for me that would be great.

I tested some other inputs in chrome and ff and it seems like it hasn't impacted other search results.