### PR TITLE
fix(search): properly index constants and make their search results better

### DIFF
--- a/src/util/search.ts
+++ b/src/util/search.ts
@@ -110,80 +110,92 @@ export function search(input: string): DocumentLink[] {
 		return [];
 	}
 
+	interface MatchContext {
+		numMatches: number;
+		lengthMatches: number;
+	}
+
 	// Build scores based on index matching
-	let result = searchIndex.value.reduce((acc: { [index: number]: number }, s) => {
+	let result = searchIndex.value.reduce((acc: Map<number, MatchContext>, s) => {
 		if (formattedInput.includes(s.name)) {
 			for (const r of s.related) {
-				if (acc[r]) {
-					acc[r]++;
+				const obj = acc.get(r);
+				if (obj) {
+					obj.numMatches += 1;
+					obj.lengthMatches += s.name.length;
 				} else {
-					acc[r] = 1;
+					acc.set(r, { numMatches: 1, lengthMatches: s.name.length });
 				}
 			}
 		}
 		return acc;
-	}, {});
+	}, new Map());
 
 	// Fallback if input is too short for matches
-	if (Object.keys(result).length === 0 && formattedInput.length < 10) {
-		result = searchIndex.value.reduce((acc: { [index: number]: number }, s) => {
+	if (result.size === 0 && formattedInput.length < 10) {
+		result = searchIndex.value.reduce((acc: Map<number, MatchContext>, s) => {
 			if (s.name.includes(formattedInput)) {
 				for (const r of s.related) {
-					if (acc[r]) {
-						acc[r]++;
+					const obj = acc.get(r);
+					if (obj) {
+						obj.numMatches += 1;
+						obj.lengthMatches += s.name.length;
 					} else {
-						acc[r] = 1;
+						acc.set(r, { numMatches: 1, lengthMatches: s.name.length });
 					}
 				}
 			}
 			return acc;
-		}, {});
+		}, new Map());
 	}
 
-	const sortedResults = Object.entries(result)
-		.map(([ref, counter]): [DocumentLink, number] => [searchRef.value[parseInt(ref, 10)], counter])
+	const sortedResults = Array.from(result.entries())
+		.map(([ref, ctx]): [DocumentLink, MatchContext] => [searchRef.value[ref], ctx])
 		.filter(([ref]) => (ref.access === 'private' ? isShowPrivates.value : true))
-		.sort(([aref, a], [bref, b]) => {
+		.sort(([aRef, aCtx], [bRef, bCtx]) => {
 			let weight = 0;
 
 			// Give extra weight when an exact match is found
-			// if it is a class or typedef, give it even higher priority
-			if (aref.nameLowerCase === formattedInput) {
-				weight += aref.isPriority ? -10 : -4;
-			} else if (bref.nameLowerCase === formattedInput) {
-				weight += bref.isPriority ? 10 : 4;
+			// If it is a class or typedef, give it even higher priority
+			if (aRef.nameLowerCase === formattedInput) {
+				weight += aRef.isPriority ? -10 : -4;
+			} else if (bRef.nameLowerCase === formattedInput) {
+				weight += bRef.isPriority ? 10 : 4;
 			}
 
-			// if your input is this long and it is a substring match of the name,
+			// If your input is this long and it is a substring match of the name,
 			// we can assume you know precisely what you're looking for, so weigh these very heavily.
-			if (formattedInput.length > 7) {
-				if (aref.cleanedComputedName.includes(formattedInput)) {
+			if (formattedInput.length >= 7) {
+				if (aRef.cleanedComputedName.includes(formattedInput)) {
 					weight -= 30;
 				}
 
-				if (bref.cleanedComputedName.includes(formattedInput)) {
+				if (bRef.cleanedComputedName.includes(formattedInput)) {
 					weight += 30;
 				}
 			}
 
-			if (a === b) {
+			if (aCtx.numMatches === bCtx.numMatches) {
 				// if the counter is the same but not the names, then give extra weight to ones that are classes and typedefs
-				if (aref.isPriority) {
+				if (aRef.isPriority) {
 					weight -= 6;
 				}
-				if (bref.isPriority) {
+				if (bRef.isPriority) {
 					weight += 6;
 				}
 
-				// in the case that there are more than two index matches, sort them by how close their length is to the input
-				if (a > 1) {
+				// In the case that there are more than two index matches, sort them by how close their length is to the input
+				if (aCtx.numMatches > 1) {
 					weight +=
-						Math.abs(formattedInput.length - aref.computedName.length) -
-						Math.abs(formattedInput.length - bref.computedName.length);
+						Math.abs(formattedInput.length - aRef.computedName.length) -
+						Math.abs(formattedInput.length - bRef.computedName.length);
 				}
-			}
 
-			return b - a + weight;
+				// Factor in the length of the match so that longer matches get a bit of priority.
+				// This prevents short words matches like 'at' or 'id' from being too high up in a search when a better match could be found
+				weight += bCtx.lengthMatches - aCtx.lengthMatches;
+			}
+			return bCtx.numMatches - aCtx.numMatches + weight;
 		});
 
 	return sortedResults.map(([ref, _]) => ref);

--- a/src/util/splitName.ts
+++ b/src/util/splitName.ts
@@ -1,7 +1,11 @@
-// Split names into 3 types of words, using userGroupDMChannel as fictional example
+// For camelcase and pascalcase, split names into 3 types of words, using userGroupDMChannel as fictional example
 // Acronyms, e.g. DM
 // Capital, e.g. Group, Channel
 // Lowercase, e.g. user
+// If the name is in screaming snake case, split by underscore
 export function splitName(name: string) {
+	if (/^[_A-Z]+$/.test(name)) {
+		return name.match(/[A-Z]+/g) ?? [];
+	}
 	return name.match(/(([A-Z]{2,})(?=[A-Z]))|[A-Z][a-z]+|[a-z]+/g) ?? [];
 }


### PR DESCRIPTION
Constants weren't being indexed properly, so searching for `pattern` wouldn't find the regex patterns for matching mentions. 

After indexing them properly I noticed that `createdAt` properties were getting matched higher because `pattern` contains the word `at` so I refactored the search a bit to include the length of match and not just the number of matches. 