### PR TITLE
Change from `Why?` to `Why DiscordJS?`

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -43,7 +43,7 @@
 			<Codeblock :code="exampleCode" />
 		</div>
 		<div>
-			<h2>Why?</h2>
+			<h2>Why DiscordJS?</h2>
 			<ul>
 				<li>Object-oriented</li>
 				<li>Speedy and efficient</li>


### PR DESCRIPTION
Things added/changed:

- Change from `Why?` to `Why DiscordJS?` on the index page.
  - IMO, I think this way looks better as it doesn't look so empty.
