### PR TITLE
fix: /docs now go to the actual documentation

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -1,7 +1,7 @@
-import { createRouter, createWebHashHistory } from 'vue-router';
+import { createRouter, createWebHistory } from 'vue-router';
 import routes from 'virtual:generated-pages';
 
 export default createRouter({
-	history: createWebHashHistory(),
+	history: createWebHistory(),
 	routes,
 });


### PR DESCRIPTION
All URL no longer have a `#/` at beginning or `#/` at end so `/docs` go to `/docs/main/stable/general/welcome` and other links such as `/null` go to 404 page as they maybe should? (maybe this could break a few bots linking the the website)

The createWebHashHistory option always has a #/, changing that to createWebHistory seemed to fix the behaviour