### PR TITLE
fix(Markdown): fix info / warn blocks with newlines not showing

### DIFF
--- a/src/util/markdown.ts
+++ b/src/util/markdown.ts
@@ -28,5 +28,5 @@ marked.use({
 
 export function markdown(input: string) {
 	const content = marked(input);
-	return content.replace(/<(info|warn)>([\s\S].+)<\/\1>/gi, '<div class="$1">$2</div>');
+	return content.replace(/<(info|warn)>(.+\n*.+)<\/\1>/gi, '<div class="$1">$2</div>');
 }

--- a/src/util/markdown.ts
+++ b/src/util/markdown.ts
@@ -28,5 +28,5 @@ marked.use({
 
 export function markdown(input: string) {
 	const content = marked(input);
-	return content.replace(/<(info|warn)>(.+\n*.+)<\/\1>/gi, '<div class="$1">$2</div>');
+	return content.replace(/<(info|warn)>([\s\S]+?)<\/\1>/gi, '<div class="$1">$2</div>');
 }


### PR DESCRIPTION
Cleans up the no longer used items from the regex too