### PR TITLE
fix: add a max-width for text readability

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -18,7 +18,7 @@
 			xl:grid xl:grid-cols-2 xl:gap-x-12 xl:max-w-7xl
 		"
 	>
-		<div class="col-span-full">
+		<div class="col-span-full max-w-prose">
 			<h2>About</h2>
 			<h3>Imagine a bot</h3>
 			<p>


### PR DESCRIPTION
Text readability usually requires line widths
up to a maximum of around 65-75 characters.
Tailwind has a class for this.