### PR TITLE
fix(css-scrollbar): transparent track with light mode

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -51,7 +51,7 @@
 
 	.custom-scroll {
 		scrollbar-width: thin;
-		scrollbar-color: theme('colors.discord.blurple.460') #1d1d1d;
+		scrollbar-color: theme('colors.discord.blurple.460') transparent;
 	}
 
 	.custom-scroll::-webkit-scrollbar {


### PR DESCRIPTION
Removes the ugly black track on the sidebar scrollbar.

Before:
![before](https://user-images.githubusercontent.com/33725716/132267476-7bdd1efd-7368-4b32-88a3-b1596abd5183.PNG)

After:
![after](https://user-images.githubusercontent.com/33725716/132267482-d0d87443-56ef-41f9-bb20-d42e95ff590d.PNG)
