### PR TITLE
fix: Correct broken `@emits` and event redirection links

### DIFF
--- a/src/components/ClassMethod.vue
+++ b/src/components/ClassMethod.vue
@@ -123,7 +123,7 @@ const returnDescription = computed(() =>
 const params = computed(() => (props.method.params ? props.method.params.filter((p) => !p.name.includes('.')) : null));
 const emits = computed(() =>
 	// @ts-expect-error
-	props.method.emits ? props.method.emits.map((e) => parseLink(e.replace('event:', 'e-'), docs.value)) : null,
+	props.method.emits ? props.method.emits.map((e) => parseLink(e, docs.value)) : null,
 );
 const scrollTo = computed(() => `${props.method.scope === 'static' ? 's-' : ''}${props.method.name}`);
 </script>

--- a/src/components/ClassMethod.vue
+++ b/src/components/ClassMethod.vue
@@ -123,7 +123,7 @@ const returnDescription = computed(() =>
 const params = computed(() => (props.method.params ? props.method.params.filter((p) => !p.name.includes('.')) : null));
 const emits = computed(() =>
 	// @ts-expect-error
-	props.method.emits ? props.method.emits.map((e) => parseLink(e.replace(/event:/i, ''), docs.value)) : null,
+	props.method.emits ? props.method.emits.map((e) => parseLink(e, docs.value)) : null,
 );
 const scrollTo = computed(() => `${props.method.scope === 'static' ? 's-' : ''}${props.method.name}`);
 </script>

--- a/src/components/ClassMethod.vue
+++ b/src/components/ClassMethod.vue
@@ -123,7 +123,7 @@ const returnDescription = computed(() =>
 const params = computed(() => (props.method.params ? props.method.params.filter((p) => !p.name.includes('.')) : null));
 const emits = computed(() =>
 	// @ts-expect-error
-	props.method.emits ? props.method.emits.map((e) => parseLink(e.replace(/:event/i, ''), docs.value)) : null,
+	props.method.emits ? props.method.emits.map((e) => parseLink(e.replace(/event:/i, ''), docs.value)) : null,
 );
 const scrollTo = computed(() => `${props.method.scope === 'static' ? 's-' : ''}${props.method.name}`);
 </script>

--- a/src/components/ClassMethod.vue
+++ b/src/components/ClassMethod.vue
@@ -123,7 +123,7 @@ const returnDescription = computed(() =>
 const params = computed(() => (props.method.params ? props.method.params.filter((p) => !p.name.includes('.')) : null));
 const emits = computed(() =>
 	// @ts-expect-error
-	props.method.emits ? props.method.emits.map((e) => parseLink(e, docs.value)) : null,
+	props.method.emits ? props.method.emits.map((e) => parseLink(e.replace('event:', 'e-'), docs.value)) : null,
 );
 const scrollTo = computed(() => `${props.method.scope === 'static' ? 's-' : ''}${props.method.name}`);
 </script>

--- a/src/util/parseLink.ts
+++ b/src/util/parseLink.ts
@@ -9,10 +9,9 @@ export function parseLink(link: string, docs: Documentation) {
 	// Type link
 	const split = link.split(/(\.|#)/);
 	if (docs.links[split[0] as any]) {
-		if (split[2]?.startsWith("event")) {
+		if (split[2]?.startsWith('e-')) {
 			// Emits tag
-			split[2] = split[2].replace("event:", "e-");
-			link = link.replace("event:", "");
+			link = link.replace('e-', '');
 		}
 
 		return {

--- a/src/util/parseLink.ts
+++ b/src/util/parseLink.ts
@@ -9,9 +9,9 @@ export function parseLink(link: string, docs: Documentation) {
 	// Type link
 	const split = link.split(/(\.|#)/);
 	if (docs.links[split[0] as any]) {
-		if (split[2]?.startsWith('e-')) {
-			// Emits tag
-			link = link.replace('e-', '');
+		if (split[2]?.startsWith('event:')) {
+			split[2] = split[2].replace('event:', 'e-');
+			link = link.replace('event:', '');
 		}
 
 		return {

--- a/src/util/parseLink.ts
+++ b/src/util/parseLink.ts
@@ -15,7 +15,6 @@ export function parseLink(link: string, docs: Documentation) {
 			link = link.replace("event:", "");
 		}
 
-		console.log(text, link)
 		return {
 			text: text ?? link,
 			link:

--- a/src/util/parseLink.ts
+++ b/src/util/parseLink.ts
@@ -9,6 +9,13 @@ export function parseLink(link: string, docs: Documentation) {
 	// Type link
 	const split = link.split(/(\.|#)/);
 	if (docs.links[split[0] as any]) {
+		if (split[2]?.startsWith("event")) {
+			// @Emits tag
+			split[2] = split[2].replace("event:", "e-");
+			link = link.replace("event:", "");
+		}
+
+		console.log(text, link)
 		return {
 			text: text ?? link,
 			link:

--- a/src/util/parseLink.ts
+++ b/src/util/parseLink.ts
@@ -10,7 +10,7 @@ export function parseLink(link: string, docs: Documentation) {
 	const split = link.split(/(\.|#)/);
 	if (docs.links[split[0] as any]) {
 		if (split[2]?.startsWith("event")) {
-			// @Emits tag
+			// Emits tag
 			split[2] = split[2].replace("event:", "e-");
 			link = link.replace("event:", "");
 		}


### PR DESCRIPTION
The `@emits` tags around the website were all malformed (and apparently, have been for a _long_ time).

Here is an [example](https://discord.js.org/#/docs/main/main/class/Collector?scrollTo=stop) from the `Collector` class:
![image](https://user-images.githubusercontent.com/33201955/133351551-bf04b982-e4ad-4868-b3eb-d87c6f615aca.png)
As you can see, both the name and the link are not quite right. The link is wrong, so nothing happens upon interaction additionally.

With this pull request, these issues will be fixed by parsing `@emits` tags.
![image](https://user-images.githubusercontent.com/33201955/133362347-a5f4e002-09b5-4cf2-8736-e3b15184f8a9.png)
