### PR TITLE
fix: Handle properties with no descriptions

### DIFF
--- a/src/components/ClassProperty.vue
+++ b/src/components/ClassProperty.vue
@@ -73,10 +73,8 @@ const route = useRoute();
 const store = useStore();
 
 const docs = computed(() => store.state.docs);
-const description = computed(() => {
-	// @ts-expect-error
-	return markdown(convertLinks(props.prop.description, docs.value, router, route) ?? '');
-});
+// @ts-expect-error
+const description = computed(() => markdown(convertLinks(props.prop.description, docs.value, router, route) ?? ''));
 const deprecatedDescription = computed(() =>
 	typeof props.prop.deprecated === 'string'
 		? // @ts-expect-error


### PR DESCRIPTION
Showing privates in [BitField](https://discord.js.org/#/docs/main/main/class/BitField) throws an error because a property there does not have a description (and doesn't render ergo):

```JavaScript
/**
 * @type {number|bigint}
 * @private
 */
BitField.defaultBit = 0;
```

Small fix!