### PR TITLE
feat: Reduced motion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ npm-debug.log*
 pids
 *.pid
 *.seed
+
+# Miscellaneous
+.DS_Store

--- a/src/components/BackToTop.vue
+++ b/src/components/BackToTop.vue
@@ -12,5 +12,7 @@
 </template>
 
 <script setup lang="ts">
-const scrollTo = () => document.getElementById('container')?.scrollTo({ top: 0, behavior: 'smooth' });
+import { isReducedMotion } from '~/util/ReducedMotion';
+const scrollTo = () =>
+	document.getElementById('container')?.scrollTo({ top: 0, behavior: isReducedMotion.value ? undefined : 'smooth' });
 </script>

--- a/src/components/BackToTop.vue
+++ b/src/components/BackToTop.vue
@@ -14,5 +14,7 @@
 <script setup lang="ts">
 import { usePreferredReducedMotion } from '~/util/ReducedMotion';
 const scrollTo = () =>
-	document.getElementById('container')?.scrollTo({ top: 0, behavior: usePreferredReducedMotion.value ? undefined : 'smooth' });
+	document
+		.getElementById('container')
+		?.scrollTo({ top: 0, behavior: usePreferredReducedMotion.value ? undefined : 'smooth' });
 </script>

--- a/src/components/BackToTop.vue
+++ b/src/components/BackToTop.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script setup lang="ts">
-import { isReducedMotion } from '~/util/ReducedMotion';
+import { usePreferredReducedMotion } from '~/util/ReducedMotion';
 const scrollTo = () =>
-	document.getElementById('container')?.scrollTo({ top: 0, behavior: isReducedMotion.value ? undefined : 'smooth' });
+	document.getElementById('container')?.scrollTo({ top: 0, behavior: usePreferredReducedMotion.value ? undefined : 'smooth' });
 </script>

--- a/src/components/ClassOverview.vue
+++ b/src/components/ClassOverview.vue
@@ -151,20 +151,20 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, ref, computed } from 'vue';
 
-import { scopedName } from '~/util/scopedName';
-import { usePreferredReducedMotion } from '~/util/ReducedMotion';
-import { isShowPrivates } from '~/util/showPrivates';
 
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue';
 import { useBreakpoints, breakpointsTailwind, whenever } from '@vueuse/core';
+import { defineProps, ref, computed } from 'vue';
 import type {
 	DocumentationClassEvent,
 	DocumentationClassMethod,
 	DocumentationClassProperty,
 } from '~/interfaces/Documentation';
+import { usePreferredReducedMotion } from '~/util/ReducedMotion';
 import { scopedName } from '~/util/scopedName';
+import { scopedName } from '~/util/scopedName';
+import { isShowPrivates } from '~/util/showPrivates';
 import { isShowPrivates } from '~/util/showPrivates';
 
 const props = defineProps<{

--- a/src/components/ClassOverview.vue
+++ b/src/components/ClassOverview.vue
@@ -154,7 +154,7 @@
 import { defineProps, ref, computed } from 'vue';
 
 import { scopedName } from '~/util/scopedName';
-import { isReducedMotion } from '~/util/ReducedMotion';
+import { usePreferredReducedMotion } from '~/util/ReducedMotion';
 import { isShowPrivates } from '~/util/showPrivates';
 
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue';
@@ -190,7 +190,7 @@ const visibleEvents = computed(() =>
 
 const scrollTo = (elementName: string) => {
 	const element = document.getElementById(`doc-for-${elementName}`);
-	element?.scrollIntoView({ behavior: isReducedMotion.value ? undefined : 'smooth', block: 'start' });
+	element?.scrollIntoView({ behavior: usePreferredReducedMotion.value ? undefined : 'smooth', block: 'start' });
 };
 
 whenever(lgAndLarger, () => (isOpen.value = true), { immediate: true });

--- a/src/components/ClassOverview.vue
+++ b/src/components/ClassOverview.vue
@@ -153,7 +153,7 @@
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue';
 import { useBreakpoints, breakpointsTailwind, whenever } from '@vueuse/core';
-import { defineProps, ref, computed } from 'vue';
+import { ref, computed } from 'vue';
 import type {
 	DocumentationClassEvent,
 	DocumentationClassMethod,

--- a/src/components/ClassOverview.vue
+++ b/src/components/ClassOverview.vue
@@ -151,8 +151,6 @@
 </template>
 
 <script setup lang="ts">
-
-
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue';
 import { useBreakpoints, breakpointsTailwind, whenever } from '@vueuse/core';
 import { defineProps, ref, computed } from 'vue';
@@ -163,8 +161,6 @@ import type {
 } from '~/interfaces/Documentation';
 import { usePreferredReducedMotion } from '~/util/ReducedMotion';
 import { scopedName } from '~/util/scopedName';
-import { scopedName } from '~/util/scopedName';
-import { isShowPrivates } from '~/util/showPrivates';
 import { isShowPrivates } from '~/util/showPrivates';
 
 const props = defineProps<{

--- a/src/components/ClassOverview.vue
+++ b/src/components/ClassOverview.vue
@@ -151,9 +151,14 @@
 </template>
 
 <script setup lang="ts">
+import { defineProps, ref, computed } from 'vue';
+
+import { scopedName } from '~/util/scopedName';
+import { isReducedMotion } from '~/util/ReducedMotion';
+import { isShowPrivates } from '~/util/showPrivates';
+
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue';
 import { useBreakpoints, breakpointsTailwind, whenever } from '@vueuse/core';
-import { ref, computed } from 'vue';
 import type {
 	DocumentationClassEvent,
 	DocumentationClassMethod,
@@ -185,7 +190,7 @@ const visibleEvents = computed(() =>
 
 const scrollTo = (elementName: string) => {
 	const element = document.getElementById(`doc-for-${elementName}`);
-	element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+	element?.scrollIntoView({ behavior: isReducedMotion.value ? undefined : 'smooth', block: 'start' });
 };
 
 whenever(lgAndLarger, () => (isOpen.value = true), { immediate: true });

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -269,8 +269,8 @@ import { ref, computed, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import MainSource from '~/data/MainSource';
 import { useStore } from '~/store';
-import { isShowPrivates } from '~/util/showPrivates';
 import { isReducedMotion, toggleReducedMotion } from '~/util/ReducedMotion';
+import { isShowPrivates } from '~/util/showPrivates';
 
 const router = useRouter();
 const route = useRoute();

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -269,7 +269,7 @@ import { ref, computed, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import MainSource from '~/data/MainSource';
 import { useStore } from '~/store';
-import { isReducedMotion, toggleReducedMotion } from '~/util/ReducedMotion';
+import { usePreferredReducedMotion, toggleReducedMotion } from '~/util/ReducedMotion';
 import { isShowPrivates } from '~/util/showPrivates';
 
 const router = useRouter();

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -108,14 +108,14 @@
 										<div class="flex justify-between px-2">
 											<SwitchLabel class="mr-4 dark:text-gray-200">Reduced Motion</SwitchLabel>
 											<Switch
-												v-model="isReducedMotion"
+												v-model="usePreferredReducedMotion"
 												class="relative inline-flex h-6 items-center rounded-full w-11 focus:outline-none"
-												:class="isReducedMotion ? 'bg-discord-blurple-500' : 'bg-gray-500'"
-												@click="toggleReducedMotion(isReducedMotion)"
+												:class="usePreferredReducedMotion ? 'bg-discord-blurple-500' : 'bg-gray-500'"
+												@click="toggleReducedMotion(usePreferredReducedMotion)"
 											>
 												<span
 													class="inline-block w-4 h-4 bg-white rounded-full transition transform-gpu z-20"
-													:class="isReducedMotion ? 'translate-x-6' : 'translate-x-1'"
+													:class="usePreferredReducedMotion ? 'translate-x-6' : 'translate-x-1'"
 												></span>
 											</Switch>
 										</div>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -106,6 +106,24 @@
 								<li>
 									<SwitchGroup>
 										<div class="flex justify-between px-2">
+											<SwitchLabel class="mr-4 dark:text-gray-200">Reduced Motion</SwitchLabel>
+											<Switch
+												v-model="isReducedMotion"
+												class="relative inline-flex h-6 items-center rounded-full w-11 focus:outline-none"
+												:class="isReducedMotion ? 'bg-discord-blurple-500' : 'bg-gray-500'"
+												@click="toggleReducedMotion(isReducedMotion)"
+											>
+												<span
+													class="inline-block w-4 h-4 bg-white rounded-full transition transform-gpu z-20"
+													:class="isReducedMotion ? 'translate-x-6' : 'translate-x-1'"
+												></span>
+											</Switch>
+										</div>
+									</SwitchGroup>
+								</li>
+								<li>
+									<SwitchGroup>
+										<div class="flex justify-between px-2">
 											<SwitchLabel class="mr-4 dark:text-gray-200">Show privates</SwitchLabel>
 											<Switch
 												v-model="isShowPrivates"
@@ -252,6 +270,7 @@ import { useRoute, useRouter } from 'vue-router';
 import MainSource from '~/data/MainSource';
 import { useStore } from '~/store';
 import { isShowPrivates } from '~/util/showPrivates';
+import { isReducedMotion, toggleReducedMotion } from '~/util/ReducedMotion';
 
 const router = useRouter();
 const route = useRoute();

--- a/src/components/Spinner.vue
+++ b/src/components/Spinner.vue
@@ -1,9 +1,19 @@
 <template>
-	<div class="relative h-10 w-10 my-60 mx-auto">
+	<div v-if="!isReducedMotion" class="relative h-10 w-10 my-60 mx-auto">
 		<div class="cube1 bg-discord-blurple-560 h-4 w-4 absolute"></div>
 		<div class="cube2 bg-discord-blurple-560 h-4 w-4 absolute"></div>
 	</div>
 </template>
+
+<script>
+import { isReducedMotion } from '~/util/ReducedMotion';
+
+export default {
+	data() {
+		return { isReducedMotion };
+	},
+};
+</script>
 
 <style>
 .cube1,

--- a/src/components/Spinner.vue
+++ b/src/components/Spinner.vue
@@ -6,14 +6,8 @@
 	<div v-else class="my-60 mx-auto text-2xl">Loading...</div>
 </template>
 
-<script>
+<script setup lang="ts">
 import { isReducedMotion } from '~/util/ReducedMotion';
-
-export default {
-	data() {
-		return { isReducedMotion };
-	},
-};
 </script>
 
 <style>

--- a/src/components/Spinner.vue
+++ b/src/components/Spinner.vue
@@ -3,6 +3,7 @@
 		<div class="cube1 bg-discord-blurple-560 h-4 w-4 absolute"></div>
 		<div class="cube2 bg-discord-blurple-560 h-4 w-4 absolute"></div>
 	</div>
+	<div v-else class="my-60 mx-auto text-2xl">Loading...</div>
 </template>
 
 <script>

--- a/src/components/Spinner.vue
+++ b/src/components/Spinner.vue
@@ -3,7 +3,9 @@
 		<div class="cube1 bg-discord-blurple-560 h-4 w-4 absolute"></div>
 		<div class="cube2 bg-discord-blurple-560 h-4 w-4 absolute"></div>
 	</div>
-	<div v-else class="my-60 mx-auto text-2xl">Loading...</div>
+	<div v-else class="dark:prose-light my-60 mx-auto text-2xl">
+		<h1>Loading...</h1>
+	</div>
 </template>
 
 <script setup lang="ts">

--- a/src/components/Spinner.vue
+++ b/src/components/Spinner.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="!isReducedMotion" class="relative h-10 w-10 my-60 mx-auto">
+	<div v-if="!usePreferredReducedMotion" class="relative h-10 w-10 my-60 mx-auto">
 		<div class="cube1 bg-discord-blurple-560 h-4 w-4 absolute"></div>
 		<div class="cube2 bg-discord-blurple-560 h-4 w-4 absolute"></div>
 	</div>
@@ -7,7 +7,7 @@
 </template>
 
 <script setup lang="ts">
-import { isReducedMotion } from '~/util/ReducedMotion';
+import { usePreferredReducedMotion } from '~/util/ReducedMotion';
 </script>
 
 <style>

--- a/src/pages/docs/[source]/[tag]/[category]/[file].vue
+++ b/src/pages/docs/[source]/[tag]/[category]/[file].vue
@@ -14,7 +14,7 @@ import { useRoute } from 'vue-router';
 import SourceButton from '~/components/SourceButton.vue';
 import { useStore } from '~/store';
 import { markdown } from '~/util/markdown';
-import { isReducedMotion } from '~/util/ReducedMotion';
+import { usePreferredReducedMotion } from '~/util/ReducedMotion';
 
 const route = useRoute();
 const store = useStore();
@@ -50,7 +50,7 @@ useHead({
 onMounted(() => {
 	const containerElement = document.getElementById('container');
 	if (containerElement && containerElement.scrollTop > 200) {
-		containerElement.scrollTo({ top: 0, behavior: isReducedMotion.value ? undefined : 'smooth' });
+		containerElement.scrollTo({ top: 0, behavior: usePreferredReducedMotion.value ? undefined : 'smooth' });
 	}
 });
 </script>

--- a/src/pages/docs/[source]/[tag]/[category]/[file].vue
+++ b/src/pages/docs/[source]/[tag]/[category]/[file].vue
@@ -14,6 +14,7 @@ import { useRoute } from 'vue-router';
 import SourceButton from '~/components/SourceButton.vue';
 import { useStore } from '~/store';
 import { markdown } from '~/util/markdown';
+import { isReducedMotion } from '~/util/ReducedMotion';
 
 const route = useRoute();
 const store = useStore();
@@ -49,7 +50,7 @@ useHead({
 onMounted(() => {
 	const containerElement = document.getElementById('container');
 	if (containerElement && containerElement.scrollTop > 200) {
-		containerElement.scrollTo({ top: 0, behavior: 'smooth' });
+		containerElement.scrollTo({ top: 0, behavior: isReducedMotion.value ? undefined : 'smooth' });
 	}
 });
 </script>

--- a/src/pages/docs/[source]/[tag]/[category]/[file].vue
+++ b/src/pages/docs/[source]/[tag]/[category]/[file].vue
@@ -13,8 +13,8 @@ import { computed, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 import SourceButton from '~/components/SourceButton.vue';
 import { useStore } from '~/store';
-import { markdown } from '~/util/markdown';
 import { usePreferredReducedMotion } from '~/util/ReducedMotion';
+import { markdown } from '~/util/markdown';
 
 const route = useRoute();
 const store = useStore();

--- a/src/pages/docs/[source]/[tag]/class/[class].vue
+++ b/src/pages/docs/[source]/[tag]/class/[class].vue
@@ -58,12 +58,11 @@ import SourceButton from '~/components/SourceButton.vue';
 import TypeLink from '~/components/TypeLink.vue';
 import Types from '~/components/Types.vue';
 import { useStore } from '~/store';
+import { isReducedMotion, usePreferredReducedMotion } from '~/util/ReducedMotion';
 import { convertLinks } from '~/util/convertLinks';
 import { markdown } from '~/util/markdown';
 import { scopedName } from '~/util/scopedName';
-import { isShowPrivates } from '~/util/showPrivates'
-import { isReducedMotion } from '~/util/ReducedMotion';
-import { usePreferredReducedMotion } from '~/util/ReducedMotion';
+import { isShowPrivates } from '~/util/showPrivates';
 import { typeKey } from '~/util/typeKey';
 
 highlight.configure({ ignoreUnescapedHTML: true });

--- a/src/pages/docs/[source]/[tag]/class/[class].vue
+++ b/src/pages/docs/[source]/[tag]/class/[class].vue
@@ -62,7 +62,8 @@ import { convertLinks } from '~/util/convertLinks';
 import { markdown } from '~/util/markdown';
 import { scopedName } from '~/util/scopedName';
 import { isShowPrivates } from '~/util/showPrivates'
-import { isReducedMotion } from '~/util/ReducedMotion';;
+import { isReducedMotion } from '~/util/ReducedMotion';
+import { usePreferredReducedMotion } from '~/util/ReducedMotion';
 import { typeKey } from '~/util/typeKey';
 
 highlight.configure({ ignoreUnescapedHTML: true });
@@ -123,11 +124,11 @@ useHead({
 
 onMounted(() => {
 	const element = document.getElementById(`doc-for-${route.query.scrollTo as string}`);
-	element?.scrollIntoView({ behavior: isReducedMotion.value ? undefined : 'smooth', block: 'start' });
+	element?.scrollIntoView({ behavior: usePreferredReducedMotion.value ? undefined : 'smooth', block: 'start' });
 
 	const containerElement = document.getElementById('container');
 	if (!route.query.scrollTo && containerElement && containerElement.scrollTop > 200) {
-		containerElement.scrollTo({ top: 0, behavior: isReducedMotion.value ? undefined : 'smooth' });
+		containerElement.scrollTo({ top: 0, behavior: usePreferredReducedMotion.value ? undefined : 'smooth' });
 	}
 
 	if (codeblock.value) {
@@ -139,7 +140,7 @@ watch(
 	() => route.query.scrollTo,
 	() => {
 		const element = document.getElementById(`doc-for-${route.query.scrollTo as string}`);
-		element?.scrollIntoView({ behavior: isReducedMotion.value ? undefined : 'smooth', block: 'start' });
+		element?.scrollIntoView({ behavior: usePreferredReducedMotion.value ? undefined : 'smooth', block: 'start' });
 	},
 );
 </script>

--- a/src/pages/docs/[source]/[tag]/class/[class].vue
+++ b/src/pages/docs/[source]/[tag]/class/[class].vue
@@ -61,7 +61,8 @@ import { useStore } from '~/store';
 import { convertLinks } from '~/util/convertLinks';
 import { markdown } from '~/util/markdown';
 import { scopedName } from '~/util/scopedName';
-import { isShowPrivates } from '~/util/showPrivates';
+import { isShowPrivates } from '~/util/showPrivates'
+import { isReducedMotion } from '~/util/ReducedMotion';;
 import { typeKey } from '~/util/typeKey';
 
 highlight.configure({ ignoreUnescapedHTML: true });
@@ -122,11 +123,11 @@ useHead({
 
 onMounted(() => {
 	const element = document.getElementById(`doc-for-${route.query.scrollTo as string}`);
-	element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+	element?.scrollIntoView({ behavior: isReducedMotion.value ? undefined : 'smooth', block: 'start' });
 
 	const containerElement = document.getElementById('container');
 	if (!route.query.scrollTo && containerElement && containerElement.scrollTop > 200) {
-		containerElement.scrollTo({ top: 0, behavior: 'smooth' });
+		containerElement.scrollTo({ top: 0, behavior: isReducedMotion.value ? undefined : 'smooth' });
 	}
 
 	if (codeblock.value) {
@@ -138,7 +139,7 @@ watch(
 	() => route.query.scrollTo,
 	() => {
 		const element = document.getElementById(`doc-for-${route.query.scrollTo as string}`);
-		element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		element?.scrollIntoView({ behavior: isReducedMotion.value ? undefined : 'smooth', block: 'start' });
 	},
 );
 </script>

--- a/src/pages/docs/[source]/[tag]/class/[class].vue
+++ b/src/pages/docs/[source]/[tag]/class/[class].vue
@@ -58,7 +58,7 @@ import SourceButton from '~/components/SourceButton.vue';
 import TypeLink from '~/components/TypeLink.vue';
 import Types from '~/components/Types.vue';
 import { useStore } from '~/store';
-import { isReducedMotion, usePreferredReducedMotion } from '~/util/ReducedMotion';
+import { usePreferredReducedMotion } from '~/util/ReducedMotion';
 import { convertLinks } from '~/util/convertLinks';
 import { markdown } from '~/util/markdown';
 import { scopedName } from '~/util/scopedName';

--- a/src/pages/docs/[source]/[tag]/typedef/[typedef].vue
+++ b/src/pages/docs/[source]/[tag]/typedef/[typedef].vue
@@ -60,6 +60,7 @@ import Types from '~/components/Types.vue';
 import { useStore } from '~/store';
 import { convertLinks } from '~/util/convertLinks';
 import { markdown } from '~/util/markdown';
+import { isReducedMotion } from '~/util/ReducedMotion';
 import { typeKey } from '~/util/typeKey';
 
 const router = useRouter();
@@ -80,7 +81,7 @@ useHead({
 onMounted(() => {
 	const containerElement = document.getElementById('container');
 	if (containerElement && containerElement.scrollTop > 200) {
-		containerElement.scrollTo({ top: 0, behavior: 'smooth' });
+		containerElement.scrollTo({ top: 0, behavior: isReducedMotion.value ? undefined : 'smooth' });
 	}
 });
 </script>

--- a/src/pages/docs/[source]/[tag]/typedef/[typedef].vue
+++ b/src/pages/docs/[source]/[tag]/typedef/[typedef].vue
@@ -58,7 +58,7 @@ import See from '~/components/See.vue';
 import SourceButton from '~/components/SourceButton.vue';
 import Types from '~/components/Types.vue';
 import { useStore } from '~/store';
-import { isReducedMotion, usePreferredReducedMotion } from '~/util/ReducedMotion';
+import { usePreferredReducedMotion } from '~/util/ReducedMotion';
 import { convertLinks } from '~/util/convertLinks';
 import { markdown } from '~/util/markdown';
 import { typeKey } from '~/util/typeKey';

--- a/src/pages/docs/[source]/[tag]/typedef/[typedef].vue
+++ b/src/pages/docs/[source]/[tag]/typedef/[typedef].vue
@@ -60,7 +60,7 @@ import Types from '~/components/Types.vue';
 import { useStore } from '~/store';
 import { convertLinks } from '~/util/convertLinks';
 import { markdown } from '~/util/markdown';
-import { isReducedMotion } from '~/util/ReducedMotion';
+import { isReducedMotion, usePreferredReducedMotion } from '~/util/ReducedMotion';
 import { typeKey } from '~/util/typeKey';
 
 const router = useRouter();
@@ -81,7 +81,7 @@ useHead({
 onMounted(() => {
 	const containerElement = document.getElementById('container');
 	if (containerElement && containerElement.scrollTop > 200) {
-		containerElement.scrollTo({ top: 0, behavior: isReducedMotion.value ? undefined : 'smooth' });
+		containerElement.scrollTo({ top: 0, behavior: usePreferredReducedMotion.value ? undefined : 'smooth' });
 	}
 });
 </script>

--- a/src/pages/docs/[source]/[tag]/typedef/[typedef].vue
+++ b/src/pages/docs/[source]/[tag]/typedef/[typedef].vue
@@ -58,9 +58,9 @@ import See from '~/components/See.vue';
 import SourceButton from '~/components/SourceButton.vue';
 import Types from '~/components/Types.vue';
 import { useStore } from '~/store';
+import { isReducedMotion, usePreferredReducedMotion } from '~/util/ReducedMotion';
 import { convertLinks } from '~/util/convertLinks';
 import { markdown } from '~/util/markdown';
-import { isReducedMotion, usePreferredReducedMotion } from '~/util/ReducedMotion';
 import { typeKey } from '~/util/typeKey';
 
 const router = useRouter();

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -22,8 +22,7 @@
 		@apply inline-block !m-0;
 	}
 
-	.reduce-motion,
-	* > * {
+	.reduce-motion * > * {
 		animation-duration: 0.01ms !important;
 		animation-iteration-count: 1 !important;
 		transition-duration: 0.01ms !important;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -21,6 +21,14 @@
 	img {
 		@apply inline-block !m-0;
 	}
+
+	.reduce-motion,
+	* > * {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
+	}
 }
 
 @layer components {

--- a/src/util/ReducedMotion.ts
+++ b/src/util/ReducedMotion.ts
@@ -8,6 +8,16 @@ localStorage.setItem(keyName, String(reducedMotionValue));
 
 export const isReducedMotion = ref(reducedMotionValue);
 
+if (reducedMotionValue) {
+	document.documentElement.classList.add('reduce-motion');
+	document.documentElement.classList.remove('full-motion');
+} else {
+	document.documentElement.classList.add('full-motion');
+	document.documentElement.classList.remove('reduce-motion');
+}
+
 export const toggleReducedMotion = (value: boolean): void => {
 	localStorage.setItem(keyName, String(value));
+	document.documentElement.classList.toggle('full-motion');
+	document.documentElement.classList.toggle('reduce-motion');
 };

--- a/src/util/ReducedMotion.ts
+++ b/src/util/ReducedMotion.ts
@@ -1,5 +1,5 @@
-import { watchEffect } from 'vue';
 import { useMediaQuery, useStorage } from '@vueuse/core';
+import { watchEffect } from 'vue';
 
 const keyName = 'reduced-motion';
 const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion)');

--- a/src/util/ReducedMotion.ts
+++ b/src/util/ReducedMotion.ts
@@ -1,0 +1,14 @@
+import { ref } from 'vue';
+
+const keyName = 'reduced-motion';
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion)').matches;
+const reducedMotionCacheValue = localStorage.getItem(keyName);
+const reducedMotionValue =
+	reducedMotionCacheValue === null ? prefersReducedMotion : reducedMotionCacheValue === 'true' ? true : false;
+localStorage.setItem(keyName, String(reducedMotionValue));
+
+export const isReducedMotion = ref(reducedMotionValue);
+
+export const toggleReducedMotion = (value: boolean): void => {
+	localStorage.setItem(keyName, String(value));
+};

--- a/src/util/ReducedMotion.ts
+++ b/src/util/ReducedMotion.ts
@@ -3,8 +3,7 @@ import { ref } from 'vue';
 const keyName = 'reduced-motion';
 const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion)').matches;
 const reducedMotionCacheValue = localStorage.getItem(keyName);
-const reducedMotionValue =
-	reducedMotionCacheValue === null ? prefersReducedMotion : reducedMotionCacheValue === 'true' ? true : false;
+const reducedMotionValue = reducedMotionCacheValue === null ? prefersReducedMotion : reducedMotionCacheValue === 'true';
 localStorage.setItem(keyName, String(reducedMotionValue));
 
 export const isReducedMotion = ref(reducedMotionValue);

--- a/src/util/ReducedMotion.ts
+++ b/src/util/ReducedMotion.ts
@@ -1,14 +1,12 @@
-import { ref } from 'vue';
+import { useMediaQuery, useStorage } from '@vueuse/core';
 
 const keyName = 'reduced-motion';
-const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion)').matches;
-const reducedMotionCacheValue = localStorage.getItem(keyName);
-const reducedMotionValue = reducedMotionCacheValue === null ? prefersReducedMotion : reducedMotionCacheValue === 'true';
-localStorage.setItem(keyName, String(reducedMotionValue));
+const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion)');
+const state = useStorage(keyName, prefersReducedMotion.value);
 
-export const isReducedMotion = ref(reducedMotionValue);
+export const usePreferredReducedMotion = prefersReducedMotion.value ? prefersReducedMotion : state;
 
-if (reducedMotionValue) {
+if (usePreferredReducedMotion.value) {
 	document.documentElement.classList.add('reduce-motion');
 	document.documentElement.classList.remove('full-motion');
 } else {
@@ -17,7 +15,7 @@ if (reducedMotionValue) {
 }
 
 export const toggleReducedMotion = (value: boolean): void => {
-	localStorage.setItem(keyName, String(value));
+	state.value = value;
 	document.documentElement.classList.toggle('full-motion');
 	document.documentElement.classList.toggle('reduce-motion');
 };

--- a/src/util/ReducedMotion.ts
+++ b/src/util/ReducedMotion.ts
@@ -1,10 +1,11 @@
+import { watchEffect } from 'vue';
 import { useMediaQuery, useStorage } from '@vueuse/core';
 
 const keyName = 'reduced-motion';
 const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion)');
 const state = useStorage(keyName, prefersReducedMotion.value);
 
-export const usePreferredReducedMotion = prefersReducedMotion.value ? prefersReducedMotion : state;
+export const usePreferredReducedMotion = state;
 
 if (usePreferredReducedMotion.value) {
 	document.documentElement.classList.add('reduce-motion');
@@ -14,8 +15,17 @@ if (usePreferredReducedMotion.value) {
 	document.documentElement.classList.remove('reduce-motion');
 }
 
+let firstLoad = true;
+
 export const toggleReducedMotion = (value: boolean): void => {
+	if (firstLoad) {
+		firstLoad = false;
+		return;
+	}
+
 	state.value = value;
 	document.documentElement.classList.toggle('full-motion');
 	document.documentElement.classList.toggle('reduce-motion');
 };
+
+watchEffect(() => toggleReducedMotion(prefersReducedMotion.value));

--- a/src/util/ReducedMotion.ts
+++ b/src/util/ReducedMotion.ts
@@ -9,9 +9,7 @@ export const usePreferredReducedMotion = state;
 
 if (usePreferredReducedMotion.value) {
 	document.documentElement.classList.add('reduce-motion');
-	document.documentElement.classList.remove('full-motion');
 } else {
-	document.documentElement.classList.add('full-motion');
 	document.documentElement.classList.remove('reduce-motion');
 }
 
@@ -24,7 +22,6 @@ export const toggleReducedMotion = (value: boolean): void => {
 	}
 
 	state.value = value;
-	document.documentElement.classList.toggle('full-motion');
 	document.documentElement.classList.toggle('reduce-motion');
 };
 


### PR DESCRIPTION
So... this is the take on preventing animations (scrolling, spinner animation etc.).

On the first visit to the website, reduced motion is enabled if detected to be preferred. Thereafter, it can be toggled.

<details>
<summary>Settings</summary>

![image](https://user-images.githubusercontent.com/33201955/137632545-63432121-382b-4c94-b860-b89f43802454.png)
</details>

This is put into the local storage as "reduced-motion" (boolean).

Had to import `usePreferredReducedMotion` where scrolling was defined because there seems to be an underlying bug where clicking on a property/method/event in the class overview _sometimes_ wouldn't work. The `scrollTo` parameter doesn't update when this happens and the CSS `.reduce-motion` is ignored and scrolls smoothly. No idea what causes this, so it was hard-coded.

Think this would be preferred by people who don't want to wait ~1 second to wait for scrolling (like me). Precious lost seconds!
