### PR TITLE
feat(Router): use HTML5 history mode instead of hash mode

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+		<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+		<link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
+		<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+		<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#090a16">
+		<meta name="apple-mobile-web-app-title" content="Discord.js Docs">
+		<meta name="application-name" content="Discord.js Docs">
+		<meta name="msapplication-TileColor" content="#090a16">
+		<meta name="theme-color" content="#090a16">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>discord.js</title>
+		<meta
+			name="description"
+			content="Discord.js is a powerful node.js module that allows you to interact with the Discord API very easily. It takes a much more object-oriented approach than most other JS Discord libraries, making your bot's code significantly tidier and easier to comprehend."
+		/>
+
+		<meta property="og:title" content="Discord.js" />
+		<meta
+			property="og:description"
+			content="Discord.js is a powerful node.js module that allows you to interact with the Discord API very easily. It takes a much more object-oriented approach than most other JS Discord libraries, making your bot's code significantly tidier and easier to comprehend."
+		/>
+		<meta property="og:image" content="https://discord.js.org/static/djs_logo.png" />
+	</head>
+	<body>
+		<noscript>
+			<strong
+				>Sorry, but the discord.js website doesn't work properly without JavaScript enabled. Please enable it to
+				continue.</strong
+			>
+		</noscript>
+		<script>
+			(() => {
+				const prefersDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+				const persistedColorPreference = localStorage.getItem('theme') || 'auto';
+				if (persistedColorPreference === 'dark' || (prefersDarkMode && persistedColorPreference !== 'light')) {
+					document.documentElement.classList.toggle('dark', true);
+				}
+			})();
+		</script>
+		<div id="app" class="h-full"></div>
+		<script type="module" src="/src/main.ts"></script>
+	</body>
+</html>

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,7 +1,7 @@
-import { createRouter, createWebHashHistory } from 'vue-router';
+import { createRouter, createWebHistory } from 'vue-router';
 import routes from 'virtual:generated-pages';
 
 export default createRouter({
-	history: createWebHashHistory(),
+	history: createWebHistory(),
 	routes,
 });


### PR DESCRIPTION
This PR makes the router use history mode which changes all URLs from `/#/` to `/`, by adding a `404.html` which is a copy of `index.html` which serves the site as it normally would so refreshing the browser does not gives the github 404 page but instead shows the site

There is a caveat though, the responses will have `404` status code which might not be ideal for SEO, another option is to use the `404.html` to redirect to `index.html` which will return the `200` code and behave the same way

A preview can be seen at [the preview](https://deploy-preview-113--discordjs-docs.netlify.app/)