### PR TITLE
Change page titles to include class/typedef name

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,17 @@
 				if (persistedColorPreference === 'dark' || (prefersDarkMode && persistedColorPreference !== 'light')) {
 					document.documentElement.classList.toggle('dark', true);
 				}
+
+				document.addEventListener('DOMNodeInserted', () => {
+					// Only do this title change for class and typedef pages
+					if (window.location.href.match(/class|typedef/g)) {
+						const classOrTypeName = window.location.href.substring(window.location.href.lastIndexOf('/') + 1);
+						const pageTitle = `discord.js | ${classOrTypeName}`;
+						if (document.title !== pageTitle) document.title = pageTitle;
+					} else {
+						if (document.title !== 'discord.js') document.title = 'discord.js';
+					}
+				});
 			})();
 		</script>
 		<div id="app" class="h-full"></div>


### PR DESCRIPTION
I agree with #115 - it would be super helpful to have the class/typedef name in the page title for when we have a ton of documentation tabs open (95% of the time)

Thankfully because of the descriptive URL paths, this can be done pretty easily with vanilla JS. This small snippet added to the `<script>` section listens for changes to the DOM and changes the page title to `discord.js | ClassName` if necessary.