### PR TITLE
fix(RESTSource): fix defaultTag for @discordjs/rest

### DIFF
--- a/src/data/RESTSource.ts
+++ b/src/data/RESTSource.ts
@@ -9,7 +9,7 @@ export default new DocsSource({
 	global: 'REST',
 	docsRepo: 'discordjs/docs',
 	repo: 'discordjs/discord.js',
-	defaultTag: 'stable',
+	defaultTag: 'main',
 	branchFilter: (branch: string) => !branchBlacklist.has(branch) && !branch.startsWith('dependabot/'),
 	tagFilter: (tag: string) =>
 		semver.gt(tag.replace(/(^@\w+\/\w+@v?)?(?<semver>\d+.\d+.\d+)-?.*/, '$<semver>'), '0.2.0'),


### PR DESCRIPTION
The **discord.js** site looks up for the `stable.json` file by default for REST API module, which doesn't exist in the docs, so it leads up to the following error message:

![fix defaultTag for @discordjs/rest](https://user-images.githubusercontent.com/20013689/155656300-ce6bd7f7-8758-47ed-b244-5d07d4e798a2.png)

I have resolved it by changing the `defaultTag` for RESTSource from **stable** to **main**, which will now look up for the `main.json` file by default.