### PR TITLE
refactor: Move GitHub button after Guide

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -20,21 +20,21 @@
 					</router-link>
 
 					<a
-						:href="`https://github.com/${repository}`"
-						class="text-gray-200 hover:bg-discord-blurple-630 hover:text-white rounded-md py-2 px-3 inline-flex items-center text-sm font-semibold focus:outline-none focus-visible:ring-1 focus-visible:ring-white"
-						target="_blank"
-						rel="noopener"
-					>
-						<span class="mr-2">GitHub</span><heroicons-outline-external-link class="h-5 w-5" />
-					</a>
-
-					<a
 						href="https://discordjs.guide"
 						class="text-gray-200 hover:bg-discord-blurple-630 hover:text-white rounded-md py-2 px-3 inline-flex items-center text-sm font-semibold focus:outline-none focus-visible:ring-1 focus-visible:ring-white"
 						target="_blank"
 						rel="noopener"
 					>
 						<span class="mr-2">Guide</span><heroicons-outline-external-link class="h-5 w-5" />
+					</a>
+
+					<a
+						:href="`https://github.com/${repository}`"
+						class="text-gray-200 hover:bg-discord-blurple-630 hover:text-white rounded-md py-2 px-3 inline-flex items-center text-sm font-semibold focus:outline-none focus-visible:ring-1 focus-visible:ring-white"
+						target="_blank"
+						rel="noopener"
+					>
+						<span class="mr-2">GitHub</span><heroicons-outline-external-link class="h-5 w-5" />
 					</a>
 				</nav>
 


### PR DESCRIPTION
This will be consistent with the guide's GitHub button placement.