### PR TITLE
feat(store): Modify global type definitions

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -325,6 +325,7 @@ export const store = createStore<State>({
 				Exclude: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#excludetype-excludedunion',
 				Omit: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys',
 				IterableIterator: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols',
+				Partial: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype'
 			};
 
 			// Add links for everything

--- a/src/store.ts
+++ b/src/store.ts
@@ -320,6 +320,7 @@ export const store = createStore<State>({
 				// TypeScript
 				any: 'https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#any',
 				unknown: 'https://www.typescriptlang.org/docs/handbook/2/functions.html#unknown',
+				readonly: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#readonlytype',
 				Readonly: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#readonlytype',
 				Record: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type',
 				Exclude: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#excludetype-excludedunion',

--- a/src/store.ts
+++ b/src/store.ts
@@ -326,7 +326,7 @@ export const store = createStore<State>({
 				Exclude: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#excludetype-excludedunion',
 				Omit: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys',
 				IterableIterator: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols',
-				Partial: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype'
+				Partial: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype',
 			};
 
 			// Add links for everything

--- a/src/store.ts
+++ b/src/store.ts
@@ -320,7 +320,7 @@ export const store = createStore<State>({
 				// TypeScript
 				any: 'https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#any',
 				unknown: 'https://www.typescriptlang.org/docs/handbook/2/functions.html#unknown',
-				readonly: 'https://www.typescriptlang.org/docs/handbook/2/classes.html#readonly',
+				Readonly: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#readonlytype',
 				Record: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type',
 				Exclude: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#excludetype-excludedunion',
 				Omit: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys',


### PR DESCRIPTION
- Adds `Partial` as a type definition globally for the documentation.
- Adds capitalised `Readonly` and fixes the link.