### PR TITLE
fix: Show return descriptions

### DIFF
--- a/src/components/ClassMethod.vue
+++ b/src/components/ClassMethod.vue
@@ -76,14 +76,7 @@
 				</span>
 				<TypeLink v-else :type="['void']" />
 				<div class="mt-3">
-					<p
-						v-if="
-							(method.returns && !Array.isArray(method.returns) && method.returns.description) ||
-							method.returnsDescription
-						"
-						class="noprose"
-						v-html="returnDescription"
-					></p>
+					<p v-if="returnDescription" class="noprose" v-html="returnDescription"></p>
 				</div>
 			</div>
 
@@ -157,7 +150,7 @@ const returnDescription = computed(() =>
 	markdown(
 		// @ts-expect-error
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-		convertLinks(props.method.returns.description ?? props.method.returnsDescription, docs.value, router, route),
+		convertLinks(props.method.returns[0]?.description, docs.value, router, route) ?? '',
 	),
 );
 const params = computed(() => (props.method.params ? props.method.params.filter((p) => !p.name.includes('.')) : null));

--- a/src/components/ClassMethod.vue
+++ b/src/components/ClassMethod.vue
@@ -48,7 +48,7 @@
 				Returns:
 				<span v-if="method.returns && Array.isArray(method.returns)">
 					<template v-if="docs!.meta!.format >= 30">
-						<template v-if="Array.isArray(method.returns[0])">
+						<template v-if="Array.isArray(method.returns?.[0])">
 							<Types v-for="rtrn in method.returns.flat()" :key="typeKey(rtrn)" :names="rtrn" />
 						</template>
 						<template v-else>
@@ -150,7 +150,7 @@ const returnDescription = computed(() =>
 	markdown(
 		// @ts-expect-error
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-		convertLinks(props.method.returns[0]?.description, docs.value, router, route) ?? '',
+		convertLinks(props.method.returns?.[0]?.description, docs.value, router, route) ?? '',
 	),
 );
 const params = computed(() => (props.method.params ? props.method.params.filter((p) => !p.name.includes('.')) : null));

--- a/src/pages/docs/[source]/[tag]/function/[function].vue
+++ b/src/pages/docs/[source]/[tag]/function/[function].vue
@@ -38,11 +38,7 @@
 				</span>
 				<TypeLink v-else :type="['void']" />
 				<div class="mt-3">
-					<p
-						v-if="(fn.returns && !Array.isArray(fn.returns) && fn.returns.description) || fn.returnsDescription"
-						class="noprose"
-						v-html="returnDescription"
-					></p>
+					<p v-if="returnDescription" class="noprose" v-html="returnDescription"></p>
 				</div>
 			</template>
 		</div>
@@ -77,7 +73,7 @@ const returnDescription = computed(() =>
 	markdown(
 		// @ts-expect-error
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-		convertLinks(fn.returns.description ?? fn.returnsDescription, docs.value, router, route),
+		convertLinks(fn.returns[0]?.description, docs.value, router, route) ?? '',
 	),
 );
 

--- a/src/pages/docs/[source]/[tag]/function/[function].vue
+++ b/src/pages/docs/[source]/[tag]/function/[function].vue
@@ -19,7 +19,7 @@
 				<h2>Returns</h2>
 				<span v-if="fn.returns && Array.isArray(fn.returns)">
 					<template v-if="docs!.meta!.format >= 30">
-						<template v-if="Array.isArray(fn.returns[0])">
+						<template v-if="Array.isArray(fn.returns?.[0])">
 							<Types v-for="rtrn in fn.returns.flat()" :key="typeKey(rtrn)" :names="rtrn" />
 						</template>
 						<template v-else>
@@ -73,7 +73,7 @@ const returnDescription = computed(() =>
 	markdown(
 		// @ts-expect-error
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-		convertLinks(fn.returns[0]?.description, docs.value, router, route) ?? '',
+		convertLinks(fn.returns?.[0]?.description, docs.value, router, route) ?? '',
 	),
 );
 

--- a/src/pages/docs/[source]/[tag]/typedef/[typedef].vue
+++ b/src/pages/docs/[source]/[tag]/typedef/[typedef].vue
@@ -33,7 +33,7 @@
 				<h2>Returns</h2>
 				<span v-if="typedef.returns && Array.isArray(typedef.returns)">
 					<template v-if="docs!.meta!.format >= 30">
-						<template v-if="Array.isArray(typedef.returns[0])">
+						<template v-if="Array.isArray(typedef.returns?.[0])">
 							<Types v-for="rtrn in typedef.returns.flat()" :key="typeKey(rtrn)" :names="rtrn" />
 						</template>
 						<template v-else>
@@ -88,7 +88,7 @@ const returnDescription = computed(() =>
 	markdown(
 		// @ts-expect-error
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-		convertLinks(typedef.returns[0]?.description, docs.value, router, route) ?? '',
+		convertLinks(typedef.returns?.[0]?.description, docs.value, router, route) ?? '',
 	),
 );
 

--- a/src/pages/docs/[source]/[tag]/typedef/[typedef].vue
+++ b/src/pages/docs/[source]/[tag]/typedef/[typedef].vue
@@ -52,14 +52,7 @@
 				</span>
 				<TypeLink v-else :type="['void']" />
 				<div class="mt-3">
-					<p
-						v-if="
-							(typedef.returns && !Array.isArray(typedef.returns) && typedef.returns.description) ||
-							typedef.returnsDescription
-						"
-						class="noprose"
-						v-html="returnDescription"
-					></p>
+					<p v-if="returnDescription" class="noprose" v-html="returnDescription"></p>
 				</div>
 			</template>
 		</div>
@@ -95,7 +88,7 @@ const returnDescription = computed(() =>
 	markdown(
 		// @ts-expect-error
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-		convertLinks(typedef.returns.description ?? typedef.returnsDescription, docs.value, router, route),
+		convertLinks(typedef.returns[0]?.description, docs.value, router, route) ?? '',
 	),
 );
 


### PR DESCRIPTION
The return of a function, method or type definition is possibly missing as well as always an array (if present). The current handling of the code made it so the return descriptions never showed as they did not take arrays into account. This was an oversight when rewriting some code, I guess.