### PR TITLE
fix: rename page title

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -54,6 +54,11 @@ import Logo from '~/components/Logo.vue';
 import Stats from '~/components/Stats.vue';
 import MainSource from '~/data/MainSource';
 import { useStore } from '~/store';
+import { useHead } from '@vueuse/head';
+
+useHead({
+	title: computed(() => 'discord.js'),
+});
 
 const store = useStore();
 


### PR DESCRIPTION
When you go to the documentation tab and then return to the homepage, the title does not return again.