### PR TITLE
Fix: return prop compatibility for previous and current doc versions

### DIFF
--- a/src/components/ClassMethod.vue
+++ b/src/components/ClassMethod.vue
@@ -52,13 +52,15 @@
 							<Types v-for="rtrn in method.returns.flat()" :key="typeKey(rtrn)" :names="rtrn" />
 						</template>
 						<template v-else>
+							<template v-for="rtrn in method.returns.flat()">
 							<Types
-								v-for="rtrn in method.returns.flat()"
-								:key="typeKey(rtrn)"
-								:names="rtrn.types?.flat()"
+								v-for="type in rtrn.types"
+								:key="typeKey(type)"
+								:names="type"
 								:variable="rtrn.variable"
 								:nullable="rtrn.nullable"
 							/>
+						    </template>
 						</template>
 					</template>
 					<template v-else>

--- a/src/components/ClassMethod.vue
+++ b/src/components/ClassMethod.vue
@@ -72,8 +72,8 @@
 						v-for="rtrn in method.returns.types"
 						:key="typeKey(rtrn)"
 						:names="rtrn"
-						:variable="rtrn.variable"
-						:nullable="rtrn.nullable"
+						:variable="method.returns.variable"
+						:nullable="method.returns.nullable"
 					/>
 				</span>
 				<TypeLink v-else :type="['void']" />
@@ -148,11 +148,10 @@ const deprecatedDescription = computed(() =>
 		  markdown(convertLinks(props.method.deprecated, docs.value, router, route))
 		: '',
 );
-const returnDescription = computed(() =>
-	markdown(
+const returnDescription = computed(() =>markdown(
 		// @ts-expect-error
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-		convertLinks(props.method.returns?.[0]?.description, docs.value, router, route) ?? '',
+		convertLinks(props.method.returns?.[0]?.description || props.method.returns?.description, docs.value, router, route) ?? '',
 	),
 );
 const params = computed(() => (props.method.params ? props.method.params.filter((p) => !p.name.includes('.')) : null));

--- a/src/components/Types.vue
+++ b/src/components/Types.vue
@@ -2,9 +2,10 @@
 	<div class="docs-type inline-block whitespace-pre-wrap">
 		<span class="font-semibold">{{ nullable ? '?' : '' }}{{ variable ? '...' : '' }}</span>
 		<span v-if="Array.isArray(names)">
-			<template v-for="(type, index) in names">
-				<span v-if="index > 0"> or </span>
-				<TypeLink :key="typeKey(type)" :type="type" />
+			<template v-for="type in names">
+				<div class="docs-type inline-block whitespace-pre-wrap">
+					<TypeLink :key="typeKey(type)" :type="type" />
+				</div>
 			</template>
 		</span>
 	</div>

--- a/src/components/Types.vue
+++ b/src/components/Types.vue
@@ -2,7 +2,10 @@
 	<div class="docs-type inline-block whitespace-pre-wrap">
 		<span class="font-semibold">{{ nullable ? '?' : '' }}{{ variable ? '...' : '' }}</span>
 		<span v-if="Array.isArray(names)">
-			<TypeLink v-for="type in names" :key="typeKey(type)" :type="type" />
+			<template v-for="(type, index) in names">
+				<span v-if="index > 0"> or </span>
+				<TypeLink :key="typeKey(type)" :type="type" />
+			</template>
 		</span>
 	</div>
 </template>

--- a/src/components/Types.vue
+++ b/src/components/Types.vue
@@ -4,8 +4,8 @@
 		<span v-if="Array.isArray(names)">
 			<template v-for="type in names">
 				<TypeLink v-if="type[1]" :key="typeKey(type)" :type="type" />
-				<div v-else class="docs-type inline-block whitespace-pre-wrap">
-					<TypeLink :key="typeKey(type)" :type="type" />
+				<div v-else :key="typeKey(type)" class="docs-type inline-block whitespace-pre-wrap">
+					<TypeLink :type="type" />
 				</div>
 			</template>
 		</span>

--- a/src/components/Types.vue
+++ b/src/components/Types.vue
@@ -1,8 +1,8 @@
 <template>
 	<div class="docs-type inline-block whitespace-pre-wrap">
- 		<span class="font-semibold">{{ nullable ? '?' : '' }}{{ variable ? '...' : '' }}</span>
- 		<span v-if="Array.isArray(names)">
- 			<TypeLink v-for="type in names" :key="typeKey(type)" :type="type" />
+		<span class="font-semibold">{{ nullable ? '?' : '' }}{{ variable ? '...' : '' }}</span>
+		<span v-if="Array.isArray(names)">
+			<TypeLink v-for="type in names" :key="typeKey(type)" :type="type" />
 		</span>
 	</div>
 </template>

--- a/src/components/Types.vue
+++ b/src/components/Types.vue
@@ -3,7 +3,8 @@
 		<span class="font-semibold">{{ nullable ? '?' : '' }}{{ variable ? '...' : '' }}</span>
 		<span v-if="Array.isArray(names)">
 			<template v-for="type in names">
-				<div class="docs-type inline-block whitespace-pre-wrap">
+				<TypeLink v-if="type[1]" :key="typeKey(type)" :type="type" />
+				<div v-else class="docs-type inline-block whitespace-pre-wrap">
 					<TypeLink :key="typeKey(type)" :type="type" />
 				</div>
 			</template>

--- a/src/components/Types.vue
+++ b/src/components/Types.vue
@@ -1,13 +1,8 @@
 <template>
 	<div class="docs-type inline-block whitespace-pre-wrap">
-		<span class="font-semibold">{{ nullable ? '?' : '' }}{{ variable ? '...' : '' }}</span>
-		<span v-if="Array.isArray(names)">
-			<template v-for="type in names">
-				<TypeLink v-if="type[1]" :key="typeKey(type)" :type="type" />
-				<div v-else :key="typeKey(type)" class="docs-type inline-block whitespace-pre-wrap">
-					<TypeLink :type="type" />
-				</div>
-			</template>
+ 		<span class="font-semibold">{{ nullable ? '?' : '' }}{{ variable ? '...' : '' }}</span>
+ 		<span v-if="Array.isArray(names)">
+ 			<TypeLink v-for="type in names" :key="typeKey(type)" :type="type" />
 		</span>
 	</div>
 </template>


### PR DESCRIPTION
Fixes missing " or " between return types.
Fixes missing return descriptions on older generated docs.
Fixes nullable return types on older generated docs

Resolves #146 

Current Docs:
[CommandInteractionOptionResolver#getMentionable](https://old.discordjs.dev/#/docs/discord.js/main/class/CommandInteractionOptionResolver?scrollTo=getMentionable)
-no "or" between return types

[v13 CommandInteractionOptionResolver#get](https://old.discordjs.dev/#/docs/discord.js/v13/class/CommandInteractionOptionResolver?scrollTo=get)
-nothing nullable and no descriptions for returns


Deploy Preview:
[CommandInteractionOptionResolver#getMentionable](https://deploy-preview-149--discordjs-docs.netlify.app/#/docs/discord.js/main/class/CommandInteractionOptionResolver?scrollTo=getMentionable)

[v13 CommandInteractionOptionResolver#get](https://deploy-preview-149--discordjs-docs.netlify.app/#/docs/discord.js/v13/class/CommandInteractionOptionResolver?scrollTo=get)