### PR TITLE
fix(MainSource): Fix invalid tag parsing

### DIFF
--- a/src/data/MainSource.ts
+++ b/src/data/MainSource.ts
@@ -8,5 +8,17 @@ export default new DocsSource({
 	docsRepo: 'discordjs/docs',
 	repo: 'discordjs/discord.js',
 	branchFilter: (branch) => branch === 'main' || /^v1[3-9]$/.test(branch),
-	tagFilter: (tag: string) => semver.gte(tag.replace(/(^@.*\/.*@v?)?(?<semver>\d+.\d+.\d+)-?.*/, '$<semver>'), '9.0.0'),
+	tagFilter: (tag: string) => {
+		const parsed = /(?:^@.*\/(?<package>.*)@v?)?(?<version>\d+.\d+.\d+)-?.*/.exec(tag);
+		const parsedPackage = /(?<package>.*)@v?-?.*/.exec(tag);
+
+		if (parsed?.groups) {
+			const isSubpackage = typeof parsed.groups.package === 'string';
+			const pkg = isSubpackage ? parsed.groups.package : parsedPackage?.groups?.package ?? 'discord.js';
+			const { version } = parsed.groups;
+			if (pkg === 'discord.js') return semver.gte(version, '12.0.0');
+		}
+
+		return false;
+	},
 });


### PR DESCRIPTION
`semver` is throwing when attempting to parse `create-discord-bot@0.1.0`. This was causing the list of versions to return an empty list.

I used the code we have in our scripts for parsing a tag and checked to ensure only discord.js tags are parsed for discord.js.

I also increased the minimum version to 12.0.0 from 9.0.0.

> [!NOTE]
> This will throw on subpackages (proxy, collection, etc.) but since those are dead, I decided to not fix them too. Maybe they can be removed in favour of the new documentation website?